### PR TITLE
Making inbound_type_slug optional

### DIFF
--- a/cdip_connector/core/schemas.py
+++ b/cdip_connector/core/schemas.py
@@ -185,7 +185,7 @@ class OutboundConfiguration(BaseModel):
     password: Optional[str] = None
     token: Optional[str] = None
     type_slug: str
-    inbound_type_slug: str
+    inbound_type_slug: Optional[str] = None
     additional: Optional[Dict[str, Any]] = {}
 
 


### PR DESCRIPTION
In the new cdip-routing flow we call the outbound integration detail endpoint which does not annotate the outbound integration model with this. For now we will make this optional and follow up with metadata on the device group to provide this additional detail