### PR TITLE
Remove semaphore from last commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cdip_connector"
-version = "0.8.4"
+version = "0.9.1"
 description = "SMART Integrate Connector Library"
 authors = [
     "Rohit Chaudhri <rohitc@vulcan.com>",


### PR DESCRIPTION
I had left in the async on a Semaphore as partial work for gathering work. But it fails when deploying with Kubeless. This PR removes it.